### PR TITLE
Create User database to store miles, lastAnsweredAt, streak

### DIFF
--- a/lib/features/authorization/presentation/sign_in/email_password_sign_in_model.dart
+++ b/lib/features/authorization/presentation/sign_in/email_password_sign_in_model.dart
@@ -2,6 +2,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
+import '../../../user/data/user_database.dart';
 import 'email_password_sign_in_strings.dart';
 import 'string_validators.dart';
 
@@ -49,8 +50,9 @@ class EmailPasswordSignInModel with EmailAndPasswordValidators, ChangeNotifier {
               EmailAuthProvider.credential(email: email, password: password));
           break;
         case EmailPasswordSignInFormType.register:
-          await firebaseAuth.createUserWithEmailAndPassword(
+          UserCredential userCredential = await firebaseAuth.createUserWithEmailAndPassword(
               email: email, password: password);
+          await UserDatabase(uid: userCredential.user!.uid).initUser();
           break;
         case EmailPasswordSignInFormType.forgotPassword:
           await firebaseAuth.sendPasswordResetEmail(email: email);

--- a/lib/features/user/data/user_database.dart
+++ b/lib/features/user/data/user_database.dart
@@ -1,0 +1,43 @@
+import '../../../repositories/firestore/firestore_path.dart';
+import '../../../repositories/firestore/firestore_service.dart';
+
+DateTime currentDateAtMidnight() {
+  DateTime now = DateTime.now();
+  return DateTime(now.year, now.month, now.day);
+}
+
+class UserDatabase {
+  UserDatabase({required this.uid});
+
+  final String uid;
+
+  final _service = FirestoreService.instance;
+
+  Future<void> initUser() => _service.setData(
+    path: FirestorePath.user(uid), 
+    data: { 'miles': 0, 'lastAnsweredAt': null }
+  );
+
+  Stream<int> milesStream() => _service.watchDocument(
+    path: FirestorePath.user(uid), 
+    builder: (data, documentID) => data?['miles']
+  );
+
+  Future<void> addMiles(int miles) => _service.incrementData(
+    path: FirestorePath.user(uid), 
+    fieldName: 'miles', 
+    incrementBy: miles
+  );
+
+  Stream<bool> hasAnsweredStream() => _service.watchDocument(
+    path: FirestorePath.user(uid),
+    builder: (data, documentID) => 
+      data?['lastAnsweredAt'] != null ? (data?['lastAnsweredAt'] as DateTime).isAfter(currentDateAtMidnight()) : false
+  );
+
+  Future<void> updateLastAnsweredAt() => _service.setData(
+    path: FirestorePath.user(uid),
+    data: { 'lastAnsweredAt': DateTime.now() },
+    merge: true
+  );
+}

--- a/lib/features/user/data/user_database_provider.dart
+++ b/lib/features/user/data/user_database_provider.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../repositories/firestore/firestore_providers.dart';
+import 'user_database.dart';
+
+/// Provides access to the [UserDatabase] associated with the logged in user,
+/// or else returns null if there is no logged in user.
+final userDatabaseProvider = Provider.autoDispose<UserDatabase?>((ref) {
+  final auth = ref.watch(authStateChangesProvider);
+
+  if (auth.asData?.value?.uid != null) {
+    return UserDatabase(uid: auth.asData!.value!.uid);
+  }
+  return null;
+});
+
+/// Provides access to a single User's miles, updating it if it changes.
+final milesStreamProvider =
+    StreamProvider.autoDispose<int>((ref) {
+  final database = ref.watch(userDatabaseProvider)!;
+  return database.milesStream();
+});
+
+/// Provides access to check if a single User has answered the daily question, updating it if it changes.
+final hasAnsweredStreamProvider =
+    StreamProvider.autoDispose<bool>((ref) {
+  final database = ref.watch(userDatabaseProvider)!;
+  return database.hasAnsweredStream();
+});

--- a/lib/repositories/firestore/firestore_path.dart
+++ b/lib/repositories/firestore/firestore_path.dart
@@ -1,5 +1,6 @@
 /// Defines the domain model path strings for [FirestoreService].
 class FirestorePath {
+  static String user(String uid) => 'users/$uid';
   static String job(String uid, String jobId) => 'users/$uid/jobs/$jobId';
   static String jobs(String uid) => 'users/$uid/jobs';
   static String entry(String uid, String entryId) =>

--- a/lib/repositories/firestore/firestore_service.dart
+++ b/lib/repositories/firestore/firestore_service.dart
@@ -17,6 +17,18 @@ class FirestoreService {
     await reference.set(data, SetOptions(merge: merge));
   }
 
+  Future<void> incrementData({
+    required String path,
+    required String fieldName,
+    required int incrementBy
+  }) async {
+    final reference = FirebaseFirestore.instance.doc(path);
+    print('$path: $fieldName: $incrementBy');
+    await reference.update({
+      fieldName: FieldValue.increment(incrementBy)
+    });
+  }
+
   Future<void> deleteData({required String path}) async {
     final reference = FirebaseFirestore.instance.doc(path);
     print('delete: $path');


### PR DESCRIPTION
The users collection firebase now stores the following fields upon registering an account:
```
{
    miles: int;
    lastUpdatedAt: DateTime;
}
```
Adds functions in `user_database.dart` to update the database and `user_database_providers` to retrieve from the database. The functions in `user_database_providers` might not work lol.